### PR TITLE
fix crawler test

### DIFF
--- a/Logic/tests/test_crawler.py
+++ b/Logic/tests/test_crawler.py
@@ -2,32 +2,30 @@ import json
 from typing import List
 
 
+def type_check(obj, expected_type):
+    if not hasattr(expected_type, "__origin__"):
+        return isinstance(obj, expected_type)
+
+    assert expected_type.__origin__ == list, "only list type is supported"
+    inner_type = expected_type.__args__[0]
+    return isinstance(obj, list) and all(type_check(item, inner_type) for item in obj)
+
+
 def check_field_types(json_file_path, expected_fields):
     with open(json_file_path, "r") as file:
         data = json.load(file)
-
-
     # check len of the data
-    assert len(data) > 1000, f"Expected at least 1000 movies, but got {len(data)}"
+    assert len(data) >= 1000, f"Expected at least 1000 movies, but got {len(data)}"
 
     # check data types
     for movie in data:
         for field, expected_type in expected_fields.items():
-            if field not in movie or movie[field] is None:
-                print(f'Expected field {field} not found in movie {movie["id"]}')
-            else:    
-                if expected_type is not None:
-                    if expected_type == str:    
-                        assert isinstance(
-                            movie[field], expected_type
-                        ), f'Expected field {field} to be of type {expected_type}, but got {type(movie[field])} in movie {movie["id"]}'
-                    if expected_type == List[str]:
-                        assert isinstance(
-                            movie[field], list
-                        ), f'Expected field {field} to be of type {expected_type}, but got {type(movie[field])} in movie {movie["id"]}'
-                        assert all(
-                            isinstance(x, str) for x in movie[field]
-                        ), f'Expected field {field} to be of type {expected_type}, but got {type(movie[field])} in movie {movie["id"]}'
+            assert (
+                field in movie and movie[field] is not None
+            ), f'Expected field {field} not found in movie {movie["id"]}'
+            assert type_check(
+                movie[field], expected_type
+            ), f'Expected field {field} to be of type {expected_type}, but got {type(movie[field])} in movie {movie["id"]}'
 
 
 expected_fields = {


### PR DESCRIPTION
the type List[List[str]] was not handled. anything with type other that str of List[str] could pass the test.

