### PR TITLE
remove NotImplementedError from BasicClassifier constructor

### DIFF
--- a/Logic/core/classification/basic_classifier.py
+++ b/Logic/core/classification/basic_classifier.py
@@ -6,7 +6,7 @@ from ..word_embedding.fasttext_model import FastText
 
 class BasicClassifier:
     def __init__(self):
-        raise NotImplementedError()
+        pass
 
     def fit(self, x, y):
         raise NotImplementedError()


### PR DESCRIPTION
all subclasses of `BasicClassifier` call `super().__init__()` in the first line of their constructor. and the only line of constructor of `BasicClassifier` is `raise NotImplementedError()`