### PR TITLE
Fix deep model last layer bug

### DIFF
--- a/Logic/core/classification/deep.py
+++ b/Logic/core/classification/deep.py
@@ -37,8 +37,7 @@ class MLPModel(nn.Module):
             nn.ReLU(),
             nn.Linear(128, 32),
             nn.ReLU(),
-            nn.Linear(32, num_classes),
-            nn.Softmax(dim=1)
+            nn.Linear(32, num_classes)
         )
 
     def forward(self, xb):


### PR DESCRIPTION
When the nn.CrossEntropyLoss is used as the criterion, regarding [pytorch documentation](https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html), the loss fuction applies the softmax on the input. Therefore, there is no need to add an extra softmax layer at the end of the model.

https://github.com/sharif-ml-lab/IMDb-IR-System/blob/ab4e92b6957fe747331744d815946b4eb6b57d90/Logic/core/classification/deep.py#L28C1-L42C10?plain=1